### PR TITLE
Update gitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 MERN Scripts/backend/.env
 MERN Scripts/backend/node_modules/
+MERN Scripts/mern-emsystem/node_modules/


### PR DESCRIPTION
Would like to git ignore node_modules in the front end so that it doesn't flood everyone with the new libraries from installing react-square-web-payments-sdk