### PR TITLE
Payment details frontend

### DIFF
--- a/MERN Scripts/backend/server.js
+++ b/MERN Scripts/backend/server.js
@@ -6,12 +6,12 @@ const nodeMailer = require('nodemailer');
 require('dotenv').config();
 const Models = require("./models.js");
 const pino = require('express-pino-logger')();
-/*
+
 const client = require('twilio')(
   process.env.TWILIO_ACCOUNT_SID,
   process.env.TWILIO_AUTH_TOKEN
 );
-*/
+
 const app  = express();
 const port = process.env.PORT || 5001;
 
@@ -109,6 +109,16 @@ app.get("/employee", (req, res)=> {
     })
 });
 
+app.get("/orderCust", (req, res)=> {
+    Models.Order.find(req.query)
+    .then((data) => {
+        console.log( 'Order read data available');
+        res.json(data);
+    })
+    .catch(() => {
+        console.log( 'error: ', daerrorta);
+    })
+});
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/MERN Scripts/backend/server.js
+++ b/MERN Scripts/backend/server.js
@@ -6,11 +6,12 @@ const nodeMailer = require('nodemailer');
 require('dotenv').config();
 const Models = require("./models.js");
 const pino = require('express-pino-logger')();
+/*
 const client = require('twilio')(
   process.env.TWILIO_ACCOUNT_SID,
   process.env.TWILIO_AUTH_TOKEN
 );
-
+*/
 const app  = express();
 const port = process.env.PORT || 5001;
 

--- a/MERN Scripts/backend/server.js
+++ b/MERN Scripts/backend/server.js
@@ -110,7 +110,7 @@ app.get("/employee", (req, res)=> {
 });
 
 app.get("/orderCust", (req, res)=> {
-    Models.Order.find(req.query)
+    Models.Order.find(req.query).sort({Datetime: req.query.order})
     .then((data) => {
         console.log( 'Order read data available');
         res.json(data);

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -1257,7 +1257,7 @@ New CSS using bootstrap
 /*Sidebar div used in Starrpage*/
 /*in use on start page*/
 .bSide {
-  margin: 3em 1.5em 0.1em 1.25em;
+  margin: 2em 1.5em 0.1em 1.25em;
 }
 
 /*First picture div used in Start page*/

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -955,7 +955,7 @@ background-color: #17458f;
   width:200px;
   height:100px;
   position: absolute;
-  right: 178px;
+  right: 300px;
   bottom: 90px;
 }
 .fire-containerRight{
@@ -1184,6 +1184,7 @@ New CSS using bootstrap
   background-color: #f4f3ef;
   font-size: calc(7px + 2vmin);
   color: black;
+  width: 100%;
   padding: 1em 2em 1em 2em;
   margin-top: 0.75em;
   margin-left: 0.5em;
@@ -1194,8 +1195,10 @@ New CSS using bootstrap
 /*in use on start page*/
 .bMainFill {
   background-color: #f4f3ef;
+  width: 100%;
   padding: 1em 2em 9.5em 2em;
   margin-right: 0.5em;
+  margin-left: 0.7em;
 }
 
 /*Green div used on Startpage*/
@@ -1205,6 +1208,7 @@ New CSS using bootstrap
   font-size: calc(7px + 2vmin);
   color: white;
   padding: 2em 5em 1.5em 0em;
+  width: 100%;
   margin-left: 0.5em;
   margin-bottom: 2em;
   margin-right: 0.5em;
@@ -1253,7 +1257,7 @@ New CSS using bootstrap
 /*Sidebar div used in Starrpage*/
 /*in use on start page*/
 .bSide {
-  margin: 1.1em 2.5em 0.1em 1.5em;
+  margin: 3em 1.5em 0.1em 1.25em;
 }
 
 /*First picture div used in Start page*/
@@ -1265,7 +1269,7 @@ New CSS using bootstrap
     border: solid 0.25em #926d4c;
     color: white;
     margin: 0em 0em 1em 0em;
-    padding: 3.5em 5.5em 3.5em 5.5em;
+    padding: 3.5em 5.5m 3.5em 5.5em;
     min-height: 190px;
 }
 
@@ -1348,6 +1352,7 @@ New CSS using bootstrap
   padding: 0.1em 0.25em 0.1em 0.25em;
   font-size: 1.75em;
   border-radius: 1em;
+  box-shadow: 5px 5px 5px black;
 }
 
 .btn-start:hover {

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -1228,7 +1228,7 @@ New CSS using bootstrap
   margin-left: 0em;
   margin-top: 1em;
   margin-bottom: 1em;
-  min-height: 800px;
+  min-height: 95%;
 }
 /*used in ETransfer Confirmation*/
 .bOrder2 {
@@ -1238,7 +1238,7 @@ New CSS using bootstrap
   padding: 2em 1em 2em 0em;
   margin-right: 0em;
   margin-top: 1em;
-  min-height: 800px;
+  height: 95%;
 }
 
 /*Used on the payment page*/
@@ -1251,7 +1251,7 @@ New CSS using bootstrap
   padding: 2em 0.5em 10em 0.5em;
   margin-right: 0em;
   margin-top: 1em;
-  min-height: 800px;
+  height: 95%;
 }
 
 /*Sidebar div used in Starrpage*/
@@ -1310,7 +1310,7 @@ New CSS using bootstrap
   background-color: #2c4356;
   box-shadow: 5px 10px black;
   border-radius: 2em;
-  margin: 2em 2em 2em 2em;
+  margin: 2em 2em 2em 1.5em;
   padding: 1.5em 1.5em 1.5em 1.5em;
   height: 20em;
   width: 90%;
@@ -1321,7 +1321,7 @@ New CSS using bootstrap
 .smallSideBox {
   display: flex;
   justify-content: center;
-  margin: em 1em 1em 1em;
+  margin: 3.5em 1em 1em 1em;
 }
 /*For the text inside the .receiptBox on SquareReceipt.js*/
 .receiptText {
@@ -1423,5 +1423,5 @@ Customer Order History table styling
 }
 
 .custBox button {
-  width: 15%;
+  width: 25%;
 }

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -1421,7 +1421,10 @@ Customer Order History table styling
   border-right: none;
   border-bottom: 1px solid black;
 }
-
-.custBox button {
-  width: 25%;
+/****Sort by selecor in CustomerHistory****/
+.custBox select{
+  width: 20%;
+  color: white;
+  background-color: grey;
+  margin-left: 80%;
 }

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -1425,8 +1425,3 @@ Customer Order History table styling
 .custBox button {
   width: 15%;
 }
-
-
-
-
-

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -1167,8 +1167,7 @@ New CSS using bootstrap
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-evenly;
-  padding: 0.5em 2em 0.5em 1em;
+  padding: 0.5em 1em 0.5em 1em;
   color: white;
 }
 /*Div for logo in nav bar*/
@@ -1261,6 +1260,7 @@ New CSS using bootstrap
 /*in use on start page*/
 .bSidebar1{
     background-image: url('components/pictures/Bundles1.svg');
+    border-radius: 0.25em;
     background-size: cover;
     border: solid 0.25em #926d4c;
     color: white;
@@ -1274,6 +1274,7 @@ New CSS using bootstrap
 .bSidebar2{
     background-image: url('components/pictures/Wood1.svg');
     background-size: cover;
+    border-radius: 0.25em;
     border: solid 0.25em #926d4c;
     color: white;
     margin: 0em 0em 1em 0em;
@@ -1285,6 +1286,7 @@ New CSS using bootstrap
 .bSidebar3{
     background-image: url('components/pictures/FirewoodTeam.jpg');
     background-size: cover;
+    border-radius: 0.25em;
     border: solid 0.25em #926d4c;
     color: white;
     margin: 0em 0em 1em 0em;

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -1232,9 +1232,9 @@ New CSS using bootstrap
   background-color: #557a65;
   font-size: calc(7px + 2vmin);
   color: white;
-  padding: 2em 5em 26.5em 0em;
-  margin-right: 2em;
-  margin-top: 0.75em;
+  padding: 2em 1em 2em 0em;
+  margin-right: 0em;
+  margin-top: 1em;
   min-height: 800px;
 }
 
@@ -1297,6 +1297,30 @@ New CSS using bootstrap
   color: white;
   margin-top: 2em;
   padding-left: 12%;
+}
+
+/*blue box in SquareRecepit.js*/
+.recepitBox {
+  background-color: #2c4356;
+  box-shadow: 5px 10px black;
+  border-radius: 2em;
+  margin: 2em 2em 2em 2em;
+  padding: 1.5em 1.5em 1.5em 1.5em;
+  height: 20em;
+  width: 90%;
+  text-align: center;
+  color: white;
+}
+/*smallerblue box in sidebar*/
+.smallSideBox {
+  display: flex;
+  justify-content: center;
+  margin: em 1em 1em 1em;
+}
+/*For the text inside the .receiptBox on SquareReceipt.js*/
+.receiptText {
+ font-family: "RobotoSlab";
+  text-align: left;
 }
 
 .bottomBorder {

--- a/MERN Scripts/mern-emsystem/src/App.css
+++ b/MERN Scripts/mern-emsystem/src/App.css
@@ -1391,4 +1391,42 @@ TODO: make dropdown display on hover
   background: none;
 }
 
+/***********************************
+Customer Order History table styling
+************************************/
+
+.custTable {
+  font-size: 14px;
+  border-radius: 0.5em;
+  font-family: "RobotoSlab";
+  text-align: center;
+  border: 1px solid black;
+}
+
+.custTable thead {
+  font-family: "BearHug";
+  font-size: 20px;
+}
+
+.custTable th {
+  border-top: 1px solid black;
+  border-left: none;
+  border-right: none;
+  border-bottom: 1px solid black;
+}
+
+.custTable td{
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: 1px solid black;
+}
+
+.custBox button {
+  width: 15%;
+}
+
+
+
+
 

--- a/MERN Scripts/mern-emsystem/src/App.js
+++ b/MERN Scripts/mern-emsystem/src/App.js
@@ -15,6 +15,7 @@ import ETransferConfirmation from './pages/ETransferConfirmation';
 import SquarePay from './pages/SquarePay';
 import SquareReceipt from './pages/SquareReceipt';
 import SuperAdmin from './pages/SuperAdmin';
+import CustOrderHist from './pages/CustOrderHist';
 import Bootstrap from './pages/Bootstrap';
 
 function App() {
@@ -26,12 +27,12 @@ function App() {
           <Route path="order" element={<Orderqty/>} />
           <Route path="login" element={<Emplogin/>} />
           <Route path="/about" element={<About/>} />
-          <Route path="/bootstrap" element={<Bootstrap/>} />
           <Route path="order/payment" element={<Payment/>} />
           <Route path="order/payment/cashConfirmation" element={<CashConfirmation/>} />
           <Route path="order/payment/ETransferConfirmation" element={<ETransferConfirmation/>} />
           <Route path="order/payment/SquarePay" element={<SquarePay/>} />
           <Route path="order/payment/SquareReceipt" element={<SquareReceipt/>} />
+          <Route path="/custhistory" element={<CustOrderHist/>} />
           <Route path="login/emp" element={<Emp/>}/>
           <Route path="login/emp/inventory" element={<Inventory/>} />
           <Route path="login/emp/history" element={<OrderHistory/>} />

--- a/MERN Scripts/mern-emsystem/src/App.js
+++ b/MERN Scripts/mern-emsystem/src/App.js
@@ -35,8 +35,6 @@ function App() {
           <Route path="/about" element={<About/>} />
           <Route path="/custhistory" element={<CustOrderHist/>} />
 
-
-
           {/*frontend protected routes*/}
           <Route element={<FrontProtectedRoutes />}>
             <Route path="order/payment" element={<Payment/>} />

--- a/MERN Scripts/mern-emsystem/src/components/Banner.js
+++ b/MERN Scripts/mern-emsystem/src/components/Banner.js
@@ -19,7 +19,7 @@ export default class Banner extends Component {
                         <Button variant="outline-light" size="sm" href="/about" style={{marginRight: 7, border: 0}}>About</Button>{' '}
                         <Button variant="outline-light" size="sm" href="https://www.facebook.com/ogopogorotary/" target="_blank" style={{marginRight: 7,border: 0}}>Facebook</Button>{' '}
                         <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank" style={{marginRight: 7,border: 0}}>Kelowna Rotary</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank" style={{marginRight: 7,border: 0}}>Camp OAC</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://www.campoac.com" target="_blank" style={{marginRight: 7,border: 0}}>Camp OAC</Button>{' '}
                         <Button variant="outline-light" size="sm" href="/login" style={{border: 0}}>Admin Portal</Button>{' '}
                     </Col>
                     <Col xl={{span:1, offset:0}} lg={{span:1,offset:0}}  md={{span:1,offset:0}} className="d-none d-lg-block d-md-block">

--- a/MERN Scripts/mern-emsystem/src/components/Banner.js
+++ b/MERN Scripts/mern-emsystem/src/components/Banner.js
@@ -16,11 +16,11 @@ export default class Banner extends Component {
                     <Col xl={{span: 5, offset:0}} lg={{span: 7, offset:1}} md={{span: 7, offset:1}} ><Link to="/" className="Link" style={{textDecoration: 'none', padding: 20 }}><h1 className="bearHug">rotary club of kelowna ogopogo</h1></Link> </Col>
                     <Col lg={{span:1, offset: 0}} md={{span:1, offset: 0}} sm={{span:1, offset: 3}} xs={{span:1, offset: 2}} className="d-xl-none d-block"><Drop/></Col>
                     <Col xl={{span:5,offset:0}} lg={{span: 5, offset:4}} className="d-none d-xl-block" id="headerButton">
-                        <Button variant="outline-light" size="sm" href="/about">About</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="https://www.facebook.com/ogopogorotary/" target="_blank">Facebook</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank">Kelowna Rotary</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank">Camp OAC</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="/login">Admin Portal</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="/about" style={{marginRight: 7, border: 0}}>About</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://www.facebook.com/ogopogorotary/" target="_blank" style={{marginRight: 7,border: 0}}>Facebook</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank" style={{marginRight: 7,border: 0}}>Kelowna Rotary</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank" style={{marginRight: 7,border: 0}}>Camp OAC</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="/login" style={{border: 0}}>Admin Portal</Button>{' '}
                     </Col>
                     <Col xl={{span:1, offset:0}} lg={{span:1,offset:0}}  md={{span:1,offset:0}} className="d-none d-lg-block d-md-block">
                         <div className="bHeadicons">

--- a/MERN Scripts/mern-emsystem/src/components/Banner.js
+++ b/MERN Scripts/mern-emsystem/src/components/Banner.js
@@ -10,7 +10,7 @@ import Button from 'react-bootstrap/esm/Button';
 export default class Banner extends Component {
     render(){
         return(
-            <Container fluid>
+            <Container fluid style={{paddingRight: 0}}>
                     <div className="bHeader">
                     <Col xl={{span:1,offset:0}} lg={1} className="d-none d-lg-block d-md-block"><Logo2 fluid /></Col>
                     <Col xl={{span: 5, offset:0}} lg={{span: 7, offset:1}} md={{span: 7, offset:1}} ><Link to="/" className="Link" style={{textDecoration: 'none', padding: 20 }}><h1 className="bearHug">rotary club of kelowna ogopogo</h1></Link> </Col>

--- a/MERN Scripts/mern-emsystem/src/components/Banner.js
+++ b/MERN Scripts/mern-emsystem/src/components/Banner.js
@@ -16,10 +16,10 @@ export default class Banner extends Component {
                     <Col xl={{span: 5, offset:0}} lg={{span: 7, offset:1}} md={{span: 7, offset:1}} ><Link to="/" className="Link" style={{textDecoration: 'none', padding: 20 }}><h1 className="bearHug">rotary club of kelowna ogopogo</h1></Link> </Col>
                     <Col lg={{span:1, offset: 0}} md={{span:1, offset: 0}} sm={{span:1, offset: 3}} xs={{span:1, offset: 2}} className="d-xl-none d-block"><Drop/></Col>
                     <Col xl={{span:5,offset:0}} lg={{span: 5, offset:4}} className="d-none d-xl-block" id="headerButton">
-                        <Button variant="outline-light" size="sm" href="/about" style={{marginRight: 7, border: 0}}>About</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="https://www.facebook.com/ogopogorotary/" target="_blank" style={{marginRight: 7,border: 0}}>Facebook</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank" style={{marginRight: 7,border: 0}}>Kelowna Rotary</Button>{' '}
-                        <Button variant="outline-light" size="sm" href="https://www.campoac.com" target="_blank" style={{marginRight: 7,border: 0}}>Camp OAC</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="/about" style={{marginRight: 4, border: 0}}>About</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank" style={{marginRight: 5,border: 0}}>Kelowna Rotary</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://www.campoac.com" target="_blank" style={{marginRight: 5,border: 0}}>Camp OAC</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="/custhistory" style={{marginRight: 5,border: 0}}>View Orders</Button>{' '}
                         <Button variant="outline-light" size="sm" href="/login" style={{border: 0}}>Admin Portal</Button>{' '}
                     </Col>
                     <Col xl={{span:1, offset:0}} lg={{span:1,offset:0}}  md={{span:1,offset:0}} className="d-none d-lg-block d-md-block">

--- a/MERN Scripts/mern-emsystem/src/components/Banner.js
+++ b/MERN Scripts/mern-emsystem/src/components/Banner.js
@@ -5,16 +5,24 @@ import Logo2 from './Logo2.js';
 import Drop from './Dropdown.js';
 import Container from 'react-bootstrap/Container';
 import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/esm/Button';
 
 export default class Banner extends Component {
     render(){
         return(
             <Container fluid>
                     <div className="bHeader">
-                    <Col lg={3} sm={2} className="d-none d-lg-block d-md-block"><Logo2 fluid /></Col>
-                    <Col><Link to="/" className="Link" style={{textDecoration: 'none', padding: 20 }}><h1 className="bearHug">rotary club of kelowna ogopogo</h1></Link> </Col>
-                    <Col lg={1}><Drop/></Col>
-                    <Col xl={{span:2, offset:0}} lg={{span:2,offset:0}}  md={{span:1,offset:0}} sm={{span:1,offset:0}} className="d-none d-lg-block d-md-block">
+                    <Col xl={{span:1,offset:0}} lg={1} className="d-none d-lg-block d-md-block"><Logo2 fluid /></Col>
+                    <Col xl={{span: 5, offset:0}} lg={{span: 7, offset:1}} md={{span: 7, offset:1}} ><Link to="/" className="Link" style={{textDecoration: 'none', padding: 20 }}><h1 className="bearHug">rotary club of kelowna ogopogo</h1></Link> </Col>
+                    <Col lg={{span:1, offset: 0}} md={{span:1, offset: 0}} sm={{span:1, offset: 3}} xs={{span:1, offset: 2}} className="d-xl-none d-block"><Drop/></Col>
+                    <Col xl={{span:5,offset:0}} lg={{span: 5, offset:4}} className="d-none d-xl-block" id="headerButton">
+                        <Button variant="outline-light" size="sm" href="/about">About</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://www.facebook.com/ogopogorotary/" target="_blank">Facebook</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank">Kelowna Rotary</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="https://portal.clubrunner.ca/824" target="_blank">Camp OAC</Button>{' '}
+                        <Button variant="outline-light" size="sm" href="/login">Admin Portal</Button>{' '}
+                    </Col>
+                    <Col xl={{span:1, offset:0}} lg={{span:1,offset:0}}  md={{span:1,offset:0}} className="d-none d-lg-block d-md-block">
                         <div className="bHeadicons">
                             <Logo fluid/>
                          </div>

--- a/MERN Scripts/mern-emsystem/src/components/Dropdown.js
+++ b/MERN Scripts/mern-emsystem/src/components/Dropdown.js
@@ -19,9 +19,9 @@ export default class Drop extends Component {
       
             <Dropdown.Menu>
               <Dropdown.Item href="/about">About</Dropdown.Item>
-              <Dropdown.Item href="https://www.facebook.com/ogopogorotary/" target="_blank">Facebook</Dropdown.Item>
               <Dropdown.Item href="https://portal.clubrunner.ca/824" target="_blank">Kelowna Rotary</Dropdown.Item>
               <Dropdown.Item href="https://www.campoac.com" target="_blank">Camp OAC</Dropdown.Item>
+              <Dropdown.Item href="/custhistory">View Orders</Dropdown.Item>
               <Dropdown.Item href="/login">Admin Portal</Dropdown.Item>
             </Dropdown.Menu>
                 </Dropdown>

--- a/MERN Scripts/mern-emsystem/src/components/Dropdown.js
+++ b/MERN Scripts/mern-emsystem/src/components/Dropdown.js
@@ -19,9 +19,9 @@ export default class Drop extends Component {
       
             <Dropdown.Menu>
               <Dropdown.Item href="/about">About</Dropdown.Item>
-              <Dropdown.Item href="https://www.facebook.com/ogopogorotary/">Facebook</Dropdown.Item>
-              <Dropdown.Item href="https://portal.clubrunner.ca/824">Kelowna Rotary</Dropdown.Item>
-              <Dropdown.Item href="https://portal.clubrunner.ca/824">Camp OAC</Dropdown.Item>
+              <Dropdown.Item href="https://www.facebook.com/ogopogorotary/" target="_blank">Facebook</Dropdown.Item>
+              <Dropdown.Item href="https://portal.clubrunner.ca/824" target="_blank">Kelowna Rotary</Dropdown.Item>
+              <Dropdown.Item href="https://portal.clubrunner.ca/824" target="_blank">Camp OAC</Dropdown.Item>
               <Dropdown.Item href="/login">Admin Portal</Dropdown.Item>
             </Dropdown.Menu>
                 </Dropdown>

--- a/MERN Scripts/mern-emsystem/src/components/Dropdown.js
+++ b/MERN Scripts/mern-emsystem/src/components/Dropdown.js
@@ -21,7 +21,7 @@ export default class Drop extends Component {
               <Dropdown.Item href="/about">About</Dropdown.Item>
               <Dropdown.Item href="https://www.facebook.com/ogopogorotary/" target="_blank">Facebook</Dropdown.Item>
               <Dropdown.Item href="https://portal.clubrunner.ca/824" target="_blank">Kelowna Rotary</Dropdown.Item>
-              <Dropdown.Item href="https://portal.clubrunner.ca/824" target="_blank">Camp OAC</Dropdown.Item>
+              <Dropdown.Item href="https://www.campoac.com" target="_blank">Camp OAC</Dropdown.Item>
               <Dropdown.Item href="/login">Admin Portal</Dropdown.Item>
             </Dropdown.Menu>
                 </Dropdown>

--- a/MERN Scripts/mern-emsystem/src/components/customerSide/CustomerHistory.js
+++ b/MERN Scripts/mern-emsystem/src/components/customerSide/CustomerHistory.js
@@ -13,7 +13,8 @@ export default class CustomerHistory extends React.Component {
     componentDidMount() {
         axios.get(`http://localhost:5001/orderCust`, { 
             params: {
-              phoneNumber: this.props.query1
+              phoneNumber: this.props.query1,
+              order: this.props.query2
             }
           })
             .then(res => {

--- a/MERN Scripts/mern-emsystem/src/components/customerSide/CustomerHistory.js
+++ b/MERN Scripts/mern-emsystem/src/components/customerSide/CustomerHistory.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import axios from 'axios';
+import Table from 'react-bootstrap/Table';
+
+export default class CustomerHistory extends React.Component {
+    constructor(props){
+      super(props);
+      this.state = {
+        orders: []
+      }
+    }
+    
+    componentDidMount() {
+        axios.get(`http://localhost:5001/orderCust`, { 
+            params: {
+              phoneNumber: this.props.query1
+            }
+          })
+            .then(res => {
+              const orderData = res.data;
+              this.setState({ orders: orderData });
+            });
+    }
+
+  
+    render() {
+
+        const handleDate = (date) => {
+            const dateArr = new String(date);
+            var newDate = "20"+dateArr.charAt(2)+dateArr.charAt(3)+"/"+dateArr.charAt(5) + dateArr.charAt(6)+"/"+dateArr.charAt(8)+dateArr.charAt(9);
+            return newDate;
+        }
+
+      return (
+          <Table className="custTable" striped="columns" variant="warning">
+            <thead>
+                <tr >
+                    <th>
+                    contact
+                    </th>
+                    <th>
+                    location / date
+                    </th>
+                    <th colSpan={2}>
+                    order details
+                    </th>
+                </tr> 
+            </thead>
+          
+  
+          {
+            this.state.orders
+              .map((content,index) =>
+            <tbody>
+                <tr key={content._id} Name={`buttons-${index}`}>  
+                  <td>
+                     {content.Name}<br></br>{content.phoneNumber}
+                  </td>
+                  <td>
+                      {content.Location}<br></br> {handleDate(content.Datetime)}
+                  </td>
+                  <td colSpan={2}>
+                  Bundles: {content.Quantity} &nbsp; ${content.Price} &nbsp; {content.Payment} <br></br> Status: {content.Status} &nbsp;|  Pickup: {content.Pickup ? "Complete" : "Incomplete"}&emsp;
+                  </td>      
+                </tr>
+            </tbody>
+              )
+          }
+        </Table>
+      )
+    }
+  }

--- a/MERN Scripts/mern-emsystem/src/pages/About.js
+++ b/MERN Scripts/mern-emsystem/src/pages/About.js
@@ -4,7 +4,7 @@ import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Banner from '../components/Banner.js';
-import FireAnimation from "../components/FireAnimation.js";
+
 
 function About(){
     const q1 = "What is this website for?";
@@ -32,7 +32,9 @@ function About(){
                             <h3 className="robotoSlab">{q1}</h3>
                             <p className="robotoSlab">{a1}</p><br></br>
                             <h3 className="robotoSlab">{q2}</h3>
-                            <p className="robotoSlab">{a2}</p><br></br>
+                            <p className="robotoSlab">{a2}</p>
+                            <a href="https://rotarykelowna.org" target="_blank">Facebook</a><br></br>
+                            <br></br>
                             <h3 className="robotoSlab">{q3}</h3>
                             <p className="robotoSlab">{a3}</p><br></br>
                             <h3 className="robotoSlab">{q4}</h3>

--- a/MERN Scripts/mern-emsystem/src/pages/CashConfirmation.js
+++ b/MERN Scripts/mern-emsystem/src/pages/CashConfirmation.js
@@ -4,35 +4,56 @@ import Banner from '../components/Banner.js';
 import Container from 'react-bootstrap/esm/Container.js';
 import Row from 'react-bootstrap/esm/Row.js';
 import Col from 'react-bootstrap/esm/Col.js';
+import Button from 'react-bootstrap/esm/Button.js';
+import cabin from '../components/pictures/Camp-OAC-Logo_Cabin.png';
 
 function CashConfirmation(){
 const navigate = useNavigate();
     return(
-    <div className="bContainer">
-    <Container fluid style={{ paddingLeft: 0, paddingRight: 0 }}>
-        <Row>
-        <Banner /> 
-        </Row>
-        <Row>
-            <Col lg={9} md={10} sm={11} xs={11} style={{ paddingLeft: 0, paddingRight: 0 }}>
-                <div className="bOrder">
-                <p> Because you have selected cash payment your order is under review , please check your email for updates from our team!
-                    (WIP, email confirmation not functioning yet)
-                    </p>
-                    <div className="buttonBox">
-                        <button className="buttonStyle" onClick={() => {navigate("/")}}>homepage</button>
+        <div className="bContainer">
+            <Container fluid style={{ paddingLeft: 0, paddingRight: 0 }}>
+                <Row>
+                <Banner /> 
+                </Row>
+                <Row>
+                <Col className="whiteSideBar"></Col> 
+                <Col xl={8} lg={8} md={8} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+                    <div className="bOrder">
+                        <Row>
+                            <Col>
+                            <div className="recepitBox">
+                                <h1 className="bearHug">thank you</h1>
+                                <br></br>
+                                    <div className="receiptText">
+                                        <p>Your order request has been successfully sent!</p>
+                                        <p>Our team review your order within 2-3 days.</p>
+                                        <p>Wait to hear back from us on your phone/email for pick-up instructions!</p>
+                                    </div>
+                                    <br></br>
+                                    <div className="buttonBox">
+                                            <Button variant="primary" size="lg" onClick={() => {navigate("/")}}>Continue Shopping</Button>
+                                    </div>
+                                </div>
+                            </Col>
+                        </Row> 
+                        <Row>
+                            <Col>                       
+                                <div className="smallSideBox">
+                                    <img src={cabin} alt="cabin" height="30%" width="40%"></img>
+                                </div>
+                            </Col>
+                        </Row>  
                     </div>
-                    
-                </div>
-            </Col>
-            <Col lg={3} md={2} sm={1} xs={1} style={{ paddingLeft: 0, paddingRight: 0 }}>
-                <div className="bOrder2">
-                    
-                </div>
-            </Col>  
-        </Row>
-    </Container>
-    </div>                        
+                </Col>
+                <Col xl={3} lg={3} md={3} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+                    <div className="bOrder2">
+                        
+                    </div>
+                </Col>  
+                <Col className="whiteSideBar"></Col> 
+            </Row>
+        </Container>
+    </div>                       
     );
 }
 

--- a/MERN Scripts/mern-emsystem/src/pages/CashConfirmation.js
+++ b/MERN Scripts/mern-emsystem/src/pages/CashConfirmation.js
@@ -27,7 +27,7 @@ const navigate = useNavigate();
                                     <div className="receiptText">
                                         <p>Your order request has been successfully sent!</p>
                                         <p>Our team review your order within 2-3 days.</p>
-                                        <p>Wait to hear back from us on your phone/email for pick-up instructions!</p>
+                                        <p>Wait to hear back from us on your phone/email for payment and pick-up instructions!</p>
                                     </div>
                                     <br></br>
                                     <div className="buttonBox">

--- a/MERN Scripts/mern-emsystem/src/pages/CustOrderHist.js
+++ b/MERN Scripts/mern-emsystem/src/pages/CustOrderHist.js
@@ -35,6 +35,10 @@ const handleReload = () => {
     window.location.reload();
 }
 
+const handleLeave = () => {
+    sessionStorage.removeItem("pNum");
+}
+
     return(
         <div className="bContainer">
         <Container fluid style={{ paddingLeft: 0, paddingRight: 0 }}>
@@ -78,9 +82,9 @@ const handleReload = () => {
                     </Row>  
                 </div>
             </Col>
-            <Col xl={2} lg={2} md={2} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+            <Col xl={2} lg={2} md={2} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }} align="center">
                 <div className="bOrder2">
-                    
+                <Button variant="outline-dark" size="lg" href="/" onClick={handleLeave} style={{border: 0, marginLeft: 18}}>Return Home</Button>{' '}
                 </div>
             </Col>  
             <Col className="whiteSideBar"></Col> 

--- a/MERN Scripts/mern-emsystem/src/pages/CustOrderHist.js
+++ b/MERN Scripts/mern-emsystem/src/pages/CustOrderHist.js
@@ -16,6 +16,10 @@ const navigate = useNavigate();
 
 var number = "";
 var data =  sessionStorage.getItem("pNum");
+var sort = -1;
+if(sessionStorage.getItem("sortKey") != null){
+    sort = sessionStorage.getItem("sortKey");
+}
 var msg = "";
 var table = true;
 if(data==null){
@@ -37,6 +41,15 @@ const handleReload = () => {
 
 const handleLeave = () => {
     sessionStorage.removeItem("pNum");
+    sessionStorage.removeItem("sortKey");
+}
+
+const handleSort = (i) => {
+    if(i == 2){
+        i = -1;
+    }
+    sessionStorage.setItem("sortKey",i);
+    handleReload();
 }
 
     return(
@@ -51,15 +64,34 @@ const handleLeave = () => {
                 <div className="bOrder">
                     <Row>
                         <Col className="custBox" align="center">
-                        <p id="topMsg" className="robotoSlab">{msg}</p>
-                            <Form.Control type="text" id="phoneNum" placeholder="Phone Number" onChange={handleClick}/>
-                            <br></br>
-                            <Button 
-                                onClick={handleReload}
-                                aria-controls="collapse-table"
-                                aria-expanded={open}
-                            >See Orders
-                            </Button>
+                            <Row>
+                                <Col>
+                                    <p id="topMsg" className="robotoSlab">{msg}</p>
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Form.Control type="text" id="phoneNum" placeholder="Phone Number" onChange={handleClick}/>
+                            </Row>
+                            <br></br>             
+                                <Button 
+                                    onClick={handleReload}
+                                    aria-controls="collapse-table"
+                                    aria-expanded={open}
+                                >See Orders
+                                </Button>
+                                <Row>
+                                <Col>
+                                <Collapse in={open}>
+                                    <div id="collapse-table">
+                                    <Form.Select onChange={(e) => handleSort(e.target.value)}  size="sm" id="sort-selector" name="sorting">
+                                        <option disabled selected>Sort By</option>
+                                        <option value="1">Oldest</option>
+                                        <option value="2">Newest</option>
+                                    </Form.Select>
+                                    </div>
+                                </Collapse>
+                                </Col>
+                                </Row>
                         </Col>
                     </Row>
                     <br></br>
@@ -67,10 +99,10 @@ const handleLeave = () => {
                       <Col>
                       <Collapse in={open} onEnter={handleClick}>
                         <div id="collapse-table">
-                            <CustomerHistory query1={data}/>
+                            <CustomerHistory query1={data} query2={sort}/>
                         </div>
                       </Collapse>
-                        
+
                       </Col>
                     </Row> 
                     <Row>

--- a/MERN Scripts/mern-emsystem/src/pages/CustOrderHist.js
+++ b/MERN Scripts/mern-emsystem/src/pages/CustOrderHist.js
@@ -1,0 +1,93 @@
+import React, {useState} from 'react';
+import { useNavigate } from "react-router-dom";
+import Banner from '../components/Banner.js';
+import Row from 'react-bootstrap/esm/Row.js';
+import Container from 'react-bootstrap/esm/Container.js';
+import Col from 'react-bootstrap/esm/Col.js';
+import Collapse from 'react-bootstrap/Collapse';
+import Form from 'react-bootstrap/Form';
+import Button from 'react-bootstrap/esm/Button.js';
+import cabin from '../components/pictures/Camp-OAC-Logo_Cabin.png';
+import CustomerHistory from '../components/customerSide/CustomerHistory.js';
+
+function CustOrderHist (){
+
+const navigate = useNavigate();
+
+var number = "";
+var data =  sessionStorage.getItem("pNum");
+var msg = "";
+var table = true;
+if(data==null){
+    table = false;
+    msg = "Enter Phone Number to see order history";
+}else{
+    msg = "Showing orders for : " + data;
+}
+const [open] = useState(table);
+
+const handleClick = () => {
+    number = document.getElementById("phoneNum").value;
+    sessionStorage.setItem("pNum",number);
+}
+
+const handleReload = () => {
+    window.location.reload();
+}
+
+    return(
+        <div className="bContainer">
+        <Container fluid style={{ paddingLeft: 0, paddingRight: 0 }}>
+            <Row>
+            <Banner /> 
+            </Row>
+            <Row>
+            <Col className="whiteSideBar"></Col> 
+            <Col xl={9} lg={9} md={9} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+                <div className="bOrder">
+                    <Row>
+                        <Col className="custBox" align="center">
+                        <p id="topMsg" className="robotoSlab">{msg}</p>
+                            <Form.Control type="text" id="phoneNum" placeholder="Phone Number" onChange={handleClick}/>
+                            <br></br>
+                            <Button 
+                                onClick={handleReload}
+                                aria-controls="collapse-table"
+                                aria-expanded={open}
+                            >See Orders
+                            </Button>
+                        </Col>
+                    </Row>
+                    <br></br>
+                    <Row>
+                      <Col>
+                      <Collapse in={open} onEnter={handleClick}>
+                        <div id="collapse-table">
+                            <CustomerHistory query1={data}/>
+                        </div>
+                      </Collapse>
+                        
+                      </Col>
+                    </Row> 
+                    <Row>
+                        <Col>                       
+                            <div className="smallSideBox">
+                                <img src={cabin} alt="cabin" height="30%" width="40%"></img>
+                            </div>
+                        </Col>
+                    </Row>  
+                </div>
+            </Col>
+            <Col xl={2} lg={2} md={2} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+                <div className="bOrder2">
+                    
+                </div>
+            </Col>  
+            <Col className="whiteSideBar"></Col> 
+        </Row>
+    </Container>
+    </div>
+    );
+}
+
+export default CustOrderHist;

--- a/MERN Scripts/mern-emsystem/src/pages/Payment.js
+++ b/MERN Scripts/mern-emsystem/src/pages/Payment.js
@@ -134,7 +134,7 @@ function post2DB(type) {
                             <Button variant="primary" size="lg" onClick={() => {post2DB("Cash"); navigate("CashConfirmation")}}>Cash</Button>
                         </Col>
                         <Col xl={{ span: 8, offset: 9 }} lg={{ span: 8, offset: 6 }} md={{ span: 1, offset: 1 }} sm={{ span: 8, offset: 11 }} xs={{ span: 8, offset: 11 }}>
-                            <Button variant="primary" size="lg" onClick={() => {post2DB("E-Transfer"); navigate("ETransferConfirmation")}}>E-Transfer</Button>
+                            <Button variant="primary" size="lg" onClick={() => {post2DB("E-Transfer"); navigate("CashConfirmation")}}>E-Transfer</Button>
                         </Col>
                     </div>
                 </Row>

--- a/MERN Scripts/mern-emsystem/src/pages/Payment.js
+++ b/MERN Scripts/mern-emsystem/src/pages/Payment.js
@@ -130,14 +130,12 @@ function post2DB(type) {
                         </Col>
                 </Row>
                 <Row>
-                    <div className="buttonBox"> 
-                        <Col xl={{ span: 1, offset: 11 }} lg={{ span: 1, offset: 8 }} md={{ span: 1, offset: 0 }} sm={{ span: 4, offset: 11 }} xs={{ span: 4, offset: 11 }}>
-                            <Button variant="primary" size="lg" onClick={() => {post2DB("Cash"); navigate("CashConfirmation")}}>Cash</Button>
-                        </Col>
-                        <Col xl={{ span: 8, offset: 9 }} lg={{ span: 8, offset: 6 }} md={{ span: 1, offset: 1 }} sm={{ span: 8, offset: 11 }} xs={{ span: 8, offset: 11 }}>
-                            <Button variant="primary" size="lg" onClick={() => {post2DB("E-Transfer"); navigate("CashConfirmation")}}>E-Transfer</Button>
-                        </Col>
-                    </div>
+                    <Col span={6} align="center">
+                        <Button variant="primary" size="lg" onClick={() => {post2DB("Cash"); navigate("CashConfirmation")}}>Cash</Button>
+                    </Col>
+                    <Col span={6} align="center">
+                        <Button variant="primary" size="lg" onClick={() => {post2DB("E-Transfer"); navigate("CashConfirmation")}}>E-Transfer</Button>
+                    </Col>
                 </Row>
             </div>
         </Col> 

--- a/MERN Scripts/mern-emsystem/src/pages/SquareReceipt.js
+++ b/MERN Scripts/mern-emsystem/src/pages/SquareReceipt.js
@@ -6,6 +6,8 @@ import CampLogo from '../components/CampLogo.js';
 import Row from 'react-bootstrap/esm/Row.js';
 import Container from 'react-bootstrap/esm/Container.js';
 import Col from 'react-bootstrap/esm/Col.js';
+import Button from 'react-bootstrap/esm/Button.js';
+import cabin from '../components/pictures/Camp-OAC-Logo_Cabin.png';
 
 function SquareReceipt(){
 const navigate = useNavigate();
@@ -16,21 +18,41 @@ const navigate = useNavigate();
             <Banner /> 
             </Row>
             <Row>
-            <Col lg={9} md={10} sm={11} xs={11} style={{ paddingLeft: 0, paddingRight: 0 }}>
-            <div className="bOrder">
-                <p> Your order has successfully been processed!
-                    Check your email for the pickup location of your firewood, it should be ready for you when you get there!
-                    </p>
-                    <div className="buttonBox">
-                            <button className="buttonStyle" onClick={() => {navigate("/")}}>homepage</button>
-                    </div>
+            <Col className="whiteSideBar"></Col> 
+            <Col xl={8} lg={8} md={8} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+                <div className="bOrder">
+                    <Row>
+                        <Col>
+                        <div className="recepitBox">
+                            <h1 className="bearHug">thank you</h1>
+                            <br></br>
+                                <div className="receiptText">
+                                    <p>Your order has been successfully processed!</p>
+                                    <p>Check your phone number/email for the order receipt, and pick-up instructions!</p>
+                                </div>
+                                <br></br>
+                                <br></br>
+                                <div className="buttonBox">
+                                        <Button variant="primary" size="lg" onClick={() => {navigate("/")}}>Continue Shopping</Button>
+                                </div>
+                            </div>
+                        </Col>
+                    </Row> 
+                    <Row>
+                        <Col>                       
+                            <div className="smallSideBox">
+                                <img src={cabin} alt="cabin" height="30%" width="40%"></img>
+                            </div>
+                        </Col>
+                    </Row>  
                 </div>
             </Col>
-            <Col lg={3} md={2} sm={1} xs={1} style={{ paddingLeft: 0, paddingRight: 0 }}>
+            <Col xl={3} lg={3} md={3} sm={12} xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
                 <div className="bOrder2">
                     
                 </div>
             </Col>  
+            <Col className="whiteSideBar"></Col> 
         </Row>
     </Container>
     </div>

--- a/MERN Scripts/mern-emsystem/src/pages/Startpage.js
+++ b/MERN Scripts/mern-emsystem/src/pages/Startpage.js
@@ -10,19 +10,12 @@ import Button from 'react-bootstrap/Button';
 import Banner from "../components/Banner.js";
 import Collapse from "react-bootstrap/Collapse";
 
-
-
-
 function Startpage(){
     const gotoOrder = useNavigate();
 
     function handleClick(){
         gotoOrder("order");
     }
-
-    
-        
-
     return(
     <div className="bContainer">
         <Container fluid style={{ paddingLeft: 0, paddingRight: 0 }}>

--- a/MERN Scripts/mern-emsystem/src/pages/Startpage.js
+++ b/MERN Scripts/mern-emsystem/src/pages/Startpage.js
@@ -29,19 +29,19 @@ function Startpage(){
                             <br></br>
                             <p className="robotoSlab">This website is designed to act as a firewood purchasing portal for Camp OAC in coordination with Kelowna Rotary Ogopogo, all proceeds go to Camp OAC.
                             </p><br></br>
-                            <p className="robotoSlab">To get started, use the Place Order button below!</p>
+                            <p className="robotoSlab">To get started, use the Order button below!</p>
                     </div>
                     <div className="bMainFill">
 
                     </div>
                     <div>
-                        <Collapse>
+                        <Col className="d-none d-xl-block">
                             <FireAnimation />
-                        </Collapse>
+                        </Col>
                     </div>
                     <div className="bMain2">
-                        <Col md={{ span: 5, offset: 5 }} xs={{span: 5, offset: 5}}>             
-                                <Button variant="start" onClick={() => handleClick()}>PLACE ORDER</Button>{' '} 
+                        <Col xl={{ span: 5, offset: 6 }} md={{ span: 5, offset: 5 }} xs={{span: 5, offset: 5}}>             
+                                <Button variant="start" onClick={() => handleClick()}>ORDER</Button>{' '} 
                         </Col>
                     </div>
                     <div>


### PR DESCRIPTION
-Make receipt page for square payment
-Pay with cash/etransfer both route to cashconfirmation.js, page styled
-Buttons on square payment now fit nice for all window sizes
-make banner resizable (dropdown expand when window large & remove logos when small)
-make dropdown links that lead to another site open in new tab
-remove facebook link from banner

-add customer history page and component
-add sorting by oldest/newest
-bOrder2,bPay2 can expand vertically based on content in bOrder and looks much better on mobile
-Fix button sizing on customer history page and receipt pages for mobile view 
-Investigated blank margin on right of banner, padding fixed

Let me know what you all think of new page and how it looks/functions, added a new variable to session storage that resets only when "Return Home" button is clicked, may need to change how this works

Notes
 - May need to make more options for sorting on customer order history

 

close #294 
close #297 
close #295 
close #276 
close #268 